### PR TITLE
Fix password changing instructions.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -79,7 +79,7 @@ that the new account password be changed. To do so, run the following command:
 
 ====
 ----
-$ curl -v -u neo4j:neo4j -X POST localhost:7474/user/neo4j/password -H "Content-type:application/json" -d "{\"password\":\"secret\"}"
+$ neo4j-admin set-initial-password secret
 ----
 ====
 


### PR DESCRIPTION
The possibility of doing this has been removed in 4 (4.1, if I am not mistaken).